### PR TITLE
Update app.py and api_client.py for Koboldcpp backend

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -5,15 +5,15 @@ import base64
 from pathlib import Path
 
 class APIClient:
-    """A client for interacting with local LLM APIs (Ollama and LM Studio)."""
+    """A client for interacting with local LLM APIs (Ollama, LM Studio, and Koboldcpp)."""
     
     def __init__(self, provider="Ollama", base_url="http://localhost:11434"):
         self.provider = provider
         self.base_url = base_url.rstrip('/')
-        if self.provider == "LM Studio":
+        if self.provider in ("LM Studio", "Koboldcpp"):
             self.api_endpoint = f"{self.base_url}/v1/chat/completions"
             self.models_endpoint = f"{self.base_url}/v1/models"
-        else: # Ollama
+        else:  # Ollama
             self.api_endpoint = f"{self.base_url}/api/chat"
             self.models_endpoint = f"{self.base_url}/api/tags"
             self.unload_endpoint = f"{self.base_url}/api/unload"
@@ -24,10 +24,22 @@ class APIClient:
             response = requests.get(self.models_endpoint, timeout=10)
             response.raise_for_status()
             data = response.json()
+            # Only show models if the backend matches the provider
             if self.provider == "LM Studio":
-                return [model['id'] for model in data.get('data', [])]
-            else: # Ollama
-                return [model['name'] for model in data.get('models', [])]
+                # If any model is owned by koboldcpp, treat as koboldcpp backend and return []
+                if data.get('object') == 'list' and any('owned_by' in m and m['owned_by'] == 'koboldcpp' for m in data.get('data', [])):
+                    return []
+                return [model['id'] for model in data.get('data', []) if model.get('owned_by', '').lower() != 'koboldcpp']
+            elif self.provider == "Koboldcpp":
+                return [model['id'] for model in data.get('data', []) if model.get('owned_by', '').lower() == 'koboldcpp' or 'owned_by' not in model]
+            elif self.provider == "Ollama":
+                # If any model is owned by koboldcpp, treat as koboldcpp backend and return []
+                if data.get('object') == 'list' and any('owned_by' in m and m['owned_by'] == 'koboldcpp' for m in data.get('data', [])):
+                    return []
+                # Only show models if owned_by is not koboldcpp
+                return [model['id'] for model in data.get('data', []) if model.get('owned_by', '').lower() != 'koboldcpp']
+            else:
+                return []
         except requests.exceptions.RequestException as e:
             print(f"Error fetching models: {e}")
             return []
@@ -38,13 +50,6 @@ class APIClient:
         with open(image_path, "rb") as image_file:
             return base64.b64encode(image_file.read()).decode('utf-8')
 
-# In api_client.py
-
-# ... (keep the rest of the file the same) ...
-# In api_client.py
-
-# ... (keep the rest of the file the same up to the function) ...
-
     def generate_chat_response(self, model, messages, images=None, stream=True):
         """
         Sends a request to the chat API and yields the response chunks.
@@ -53,7 +58,7 @@ class APIClient:
         
         if images and messages and messages[-1]['role'] == 'user':
             last_message = messages[-1]
-            if self.provider == "LM Studio":
+            if self.provider in ("LM Studio", "Koboldcpp"):
                 content_parts = [{"type": "text", "text": last_message['content']}]
                 for img_path in images:
                     b64_img = self._encode_image(img_path)
@@ -75,44 +80,48 @@ class APIClient:
         try:
             with requests.post(self.api_endpoint, headers=headers, json=payload, stream=True, timeout=300) as response:
                 response.raise_for_status()
-                for line in response.iter_lines():
-                    if line:
-                        # Decode the line from bytes to a string
-                        decoded_line = line.decode('utf-8')
-                        raw_response_for_debugging += decoded_line + '\n'
-
-                        # --- THIS IS THE CRUCIAL FIX ---
-                        # SSE messages start with "data: ", we need to strip this prefix.
-                        if decoded_line.startswith('data: '):
-                            json_str = decoded_line[6:].strip()  # Slice off "data: " and strip whitespace
-                            
-                            # LM Studio sends a [DONE] message to indicate the end of the stream
-                            if json_str == "[DONE]":
-                                break
-                            
-                            # Sometimes empty data lines are sent as keep-alives
-                            if not json_str:
-                                continue
-
-                            # Now we can safely parse the JSON
-                            chunk = json.loads(json_str)
-                            
-                            if self.provider == "LM Studio":
-                                content = chunk['choices'][0]['delta'].get('content', '')
-                            else: # Ollama
-                                content = chunk['message'].get('content', '')
-                            
-                            if content:
-                                yield content
-                        
-                        # Handle non-SSE Ollama responses (just in case)
-                        elif "{" in decoded_line:
-                            chunk = json.loads(decoded_line)
-                            content = chunk.get('message', {}).get('content', '')
-                            if content:
-                                yield content
-
-
+                if self.provider == "Koboldcpp":
+                    # Koboldcpp streams SSE lines: each line starts with 'data: '
+                    for line in response.iter_lines():
+                        if line:
+                            decoded_line = line.decode('utf-8')
+                            raw_response_for_debugging += decoded_line + '\n'
+                            if decoded_line.startswith('data: '):
+                                json_str = decoded_line[6:].strip()
+                                if json_str == "[DONE]":
+                                    break
+                                if not json_str:
+                                    continue
+                                try:
+                                    chunk = json.loads(json_str)
+                                    content = chunk['choices'][0]['delta'].get('content', '')
+                                    if content:
+                                        yield content
+                                except Exception:
+                                    continue
+                else:
+                    for line in response.iter_lines():
+                        if line:
+                            decoded_line = line.decode('utf-8')
+                            raw_response_for_debugging += decoded_line + '\n'
+                            if decoded_line.startswith('data: '):
+                                json_str = decoded_line[6:].strip()
+                                if json_str == "[DONE]":
+                                    break
+                                if not json_str:
+                                    continue
+                                chunk = json.loads(json_str)
+                                if self.provider == "LM Studio":
+                                    content = chunk['choices'][0]['delta'].get('content', '')
+                                else: # Ollama
+                                    content = chunk['message'].get('content', '')
+                                if content:
+                                    yield content
+                            elif "{" in decoded_line:
+                                chunk = json.loads(decoded_line)
+                                content = chunk.get('message', {}).get('content', '')
+                                if content:
+                                    yield content
         except requests.exceptions.RequestException as e:
             yield f"--- \n**API Connection Error:**\n\n`{e}`"
         except json.JSONDecodeError as e:
@@ -122,14 +131,10 @@ class APIClient:
                 f"**Full raw response from server:**\n\n```\n{raw_response_for_debugging or 'Response was empty.'}\n```"
             )
 
-# ... (rest of the file is the same) ...
-# ... (rest of the file is the same) ...
-
     def unload_model(self, model_name):
         """Unloads a model from memory (Ollama only)."""
         if self.provider != "Ollama":
-            return {"status": "Unsupported for LM Studio"}
-        
+            return {"status": "Unsupported for LM Studio and Koboldcpp"}
         try:
             response = requests.post(self.unload_endpoint, json={"name": model_name}, timeout=20)
             response.raise_for_status()


### PR DESCRIPTION
This change adds Koboldcpp as a backend in addition to LLM Studio and Ollama. Koboldcpp is hassle free backend as opposed to LLM Studio and Ollama. Users would need to run koboldcpp load their Text Model and Vision mmproj in the Loaded Files menue, then click on Launch. Koboldcpp should connect at port 5001 (note if it connects at a different port). In the Image-to-Prompt AI Assistant UI, the user need to select the Koboldcpp radio button, change the API Base URL to the port that koboldcpp connected to (5001 or other one) then from the Select Mode(s) drop down list select the model.
Users no longer have to redownload existing vision models through LLM Studio or Ollama. Koboldcpp allows users to select existing vision models on their PCs.
Users can switch for port 1234 to use LLM Studio or Ollama.

![Screenshot 2025-06-12 225900](https://github.com/user-attachments/assets/5398047b-448d-470f-ac4d-6fc089cbdae1)
![Screenshot 2025-06-12 225933](https://github.com/user-attachments/assets/10f13f79-78e4-40bd-b839-5d2937a0ff79)
![Screenshot 2025-06-12 230519](https://github.com/user-attachments/assets/876acf4f-551c-446e-b3c0-db5f86049a19)
